### PR TITLE
A Small Orange One click Change

### DIFF
--- a/services.json
+++ b/services.json
@@ -111,7 +111,7 @@
             "title": "A Small Orange",
             "URL": "https://www.asmallorange.com/",
             "setup": "https://help.asmallorange.com/index.php?/Knowledgebase/Article/View/283/0/installing-ghost-033-with-a-mysql-database",
-            "one-click": false,
+            "one-click": true,
             "support-level": "full",
             "verified": false
         }


### PR DESCRIPTION
We have now added support for one click installations of Ghost at A Small Orange (on shared as well as other hosting plans).

Please let me know if this needs to go in gh-pages or base. Thanks!
