### PR TITLE
Add nodejitsu to the list of hosters

### DIFF
--- a/services.json
+++ b/services.json
@@ -101,7 +101,7 @@
 
         },
         {
-            "title": "Ghoster",             
+            "title": "Ghoster",
             "URL": "http://ghoster.io",
             "setup": false,
             "support-level": "full",
@@ -111,6 +111,14 @@
             "title": "A Small Orange",
             "URL": "https://www.asmallorange.com/",
             "setup": "https://help.asmallorange.com/index.php?/Knowledgebase/Article/View/283/0/installing-ghost-033-with-a-mysql-database",
+            "one-click": false,
+            "support-level": "full",
+            "verified": false
+        },
+        {
+            "title": "Nodejitsu",
+            "URL": "https://www.nodejitsu.com/",
+            "setup": "http://blog.nodejitsu.com/persistent-ghost-blogging",
             "one-click": false,
             "support-level": "full",
             "verified": false


### PR DESCRIPTION
Not sure if this could be considered one-click, its basically `jitsu install ghost && cd ghost && jitsu deploy` ;)

Some redundant spaces got auto-removed. :beers:
